### PR TITLE
[WIP] Custom Encoder/Decoder for YAML Format

### DIFF
--- a/examples/fodo.py
+++ b/examples/fodo.py
@@ -13,6 +13,8 @@ from schema.QuadrupoleElement import QuadrupoleElement
 
 from schema.Line import Line
 
+from utils import io
+
 
 def main():
     drift1 = DriftElement(
@@ -52,7 +54,9 @@ def main():
         ]
     )
     # Serialize to YAML
-    yaml_data = yaml.dump(line.model_dump(), default_flow_style=False)
+    yaml_data = yaml.dump(
+        io.custom_encoder(line.model_dump()), default_flow_style=False
+    )
     print("Dumping YAML data...")
     print(f"{yaml_data}")
     # Write YAML data to file
@@ -63,7 +67,7 @@ def main():
     with open(yaml_file, "r") as file:
         yaml_data = yaml.safe_load(file)
     # Parse YAML data
-    loaded_line = Line(**yaml_data)
+    loaded_line = Line(**io.custom_decoder(yaml_data))
     # Validate loaded data
     assert line == loaded_line
     # Serialize to JSON

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,24 @@
+def custom_encoder(data):
+    if isinstance(data, dict):
+        kind = data.get("kind")
+        if kind in ["Drift", "Quadrupole"]:
+            return {kind: {k: v for k, v in data.items() if k != "kind"}}
+        return {k: custom_encoder(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [custom_encoder(item) for item in data]
+    else:
+        return data
+
+
+def custom_decoder(data):
+    if isinstance(data, dict):
+        if len(data) == 1:
+            kind, element_data = next(iter(data.items()))
+            if kind in ["Drift", "Quadrupole"]:
+                element_data["kind"] = kind
+                return element_data
+        return {k: custom_decoder(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [custom_decoder(item) for item in data]
+    else:
+        return data


### PR DESCRIPTION
This is a prototype of custom encoding/decoding for YAML format that could be done to achieve what was discussed in https://github.com/campa-consortium/pals-python/pull/3#pullrequestreview-2800221980 and https://github.com/campa-consortium/pals-python/pull/3#issuecomment-2836093025.

The custom encoding/decoding produces this (custom YAML)
```yaml
kind: Line
line:
- Drift:
    length: 0.25
    name: drift1
- Quadrupole:
    MagneticMultipoleP:
      Bn1: 1.0
    length: 1.0
    name: quad1
- Drift:
    length: 0.5
    name: drift2
- Quadrupole:
    MagneticMultipoleP:
      Bn1: -1.0
    length: 1.0
    name: quad2
- Drift:
    length: 0.5
    name: drift3
```

instead of this (standard YAML)
```yaml
kind: Line
line:
- kind: Drift
  length: 0.25
  name: drift1
- MagneticMultipoleP:
    Bn1: 1.0
  kind: Quadrupole
  length: 1.0
  name: quad1
- kind: Drift
  length: 0.5
  name: drift2
- MagneticMultipoleP:
    Bn1: -1.0
  kind: Quadrupole
  length: 1.0
  name: quad2
- kind: Drift
  length: 0.5
  name: drift3
```

I think it should be possible to achieve the same by implementing element custom wrappers as well. I could implement this alternative solution in a separate PR and then we could compare the two solutions and decide if we want to go forward with any of these.

It still seems to me like customization that could be postponed and/or avoided altogether.