### PR TITLE
[WIP] Example of Custom Element Wrapper

### DIFF
--- a/examples/fodo.py
+++ b/examples/fodo.py
@@ -12,6 +12,7 @@ from schema.DriftElement import DriftElement
 from schema.QuadrupoleElement import QuadrupoleElement
 
 from schema.Line import Line
+from schema.ElementWrapper import ElementWrapper
 
 
 def main():
@@ -44,15 +45,15 @@ def main():
     # Create line with all elements
     line = Line(
         line=[
-            drift1,
-            quad1,
-            drift2,
-            quad2,
-            drift3,
+            ElementWrapper(element=drift1),
+            ElementWrapper(element=quad1),
+            ElementWrapper(element=drift2),
+            ElementWrapper(element=quad2),
+            ElementWrapper(element=drift3),
         ]
     )
     # Serialize to YAML
-    yaml_data = yaml.dump(line.model_dump(), default_flow_style=False)
+    yaml_data = yaml.dump(line.to_dict(), default_flow_style=False)
     print("Dumping YAML data...")
     print(f"{yaml_data}")
     # Write YAML data to file
@@ -63,11 +64,11 @@ def main():
     with open(yaml_file, "r") as file:
         yaml_data = yaml.safe_load(file)
     # Parse YAML data
-    loaded_line = Line(**yaml_data)
+    loaded_line = Line.from_dict(yaml_data)
     # Validate loaded data
     assert line == loaded_line
     # Serialize to JSON
-    json_data = json.dumps(line.model_dump(), sort_keys=True, indent=2)
+    json_data = json.dumps(line.to_dict(), sort_keys=True, indent=2)
     print("Dumping JSON data...")
     print(f"{json_data}")
     # Write JSON data to file
@@ -78,7 +79,7 @@ def main():
     with open(json_file, "r") as file:
         json_data = json.loads(file.read())
     # Parse JSON data
-    loaded_line = Line(**json_data)
+    loaded_line = Line.from_dict(json_data)
     # Validate loaded data
     assert line == loaded_line
 

--- a/schema/ElementWrapper.py
+++ b/schema/ElementWrapper.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, Field
+from typing import Annotated, Literal, Union
+from schema.BaseElement import BaseElement
+from schema.ThickElement import ThickElement
+from schema.DriftElement import DriftElement
+from schema.QuadrupoleElement import QuadrupoleElement
+
+
+class ElementWrapper(BaseModel):
+    """Base class for element wrappers"""
+
+    kind: Literal["ElementWrapper"] = "ElementWrapper"
+
+    element: Annotated[
+        Union[
+            BaseElement,
+            ThickElement,
+            DriftElement,
+            QuadrupoleElement,
+        ],
+        Field(discriminator="kind"),
+    ]
+
+    def to_dict(self):
+        element_dict = self.element.model_dump()
+        kind = element_dict.pop("kind")
+        return {kind: element_dict}
+
+    @classmethod
+    def from_dict(cls, data):
+        kind = next(iter(data))
+        element_data = data[kind]
+        element_data["kind"] = kind
+        element_class = {
+            "Drift": DriftElement,
+            "Quadrupole": QuadrupoleElement,
+        }[kind]
+        element = element_class(**element_data)
+        return cls(element=element)

--- a/schema/Line.py
+++ b/schema/Line.py
@@ -1,10 +1,7 @@
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Annotated, List, Literal, Union
+from pydantic import BaseModel, ConfigDict
+from typing import List, Literal
 
-from schema.BaseElement import BaseElement
-from schema.ThickElement import ThickElement
-from schema.DriftElement import DriftElement
-from schema.QuadrupoleElement import QuadrupoleElement
+from schema.ElementWrapper import ElementWrapper
 
 
 class Line(BaseModel):
@@ -16,18 +13,15 @@ class Line(BaseModel):
 
     kind: Literal["Line"] = "Line"
 
-    line: List[
-        Annotated[
-            Union[
-                BaseElement,
-                ThickElement,
-                DriftElement,
-                QuadrupoleElement,
-                "Line",
-            ],
-            Field(discriminator="kind"),
-        ]
-    ]
+    line: List[ElementWrapper]
+
+    def to_dict(self):
+        return {"kind": self.kind, "line": [element.to_dict() for element in self.line]}
+
+    @classmethod
+    def from_dict(cls, data):
+        line_elements = [ElementWrapper.from_dict(element) for element in data["line"]]
+        return cls(line=line_elements)
 
 
 # Avoid circular import issues


### PR DESCRIPTION
This is a prototype of custom element wrapper that could be done to achieve what was discussed in https://github.com/campa-consortium/pals-python/pull/3#pullrequestreview-2800221980 and https://github.com/campa-consortium/pals-python/pull/3#issuecomment-2836093025.

In YAML format, the custom element wrapper produces this format
```yaml
kind: Line
line:
- Drift:
    length: 0.25
    name: drift1
- Quadrupole:
    MagneticMultipoleP:
      Bn1: 1.0
    length: 1.0
    name: quad1
- Drift:
    length: 0.5
    name: drift2
- Quadrupole:
    MagneticMultipoleP:
      Bn1: -1.0
    length: 1.0
    name: quad2
- Drift:
    length: 0.5
    name: drift3
```
instead of this format
```yaml
kind: Line
line:
- kind: Drift
  length: 0.25
  name: drift1
- MagneticMultipoleP:
    Bn1: 1.0
  kind: Quadrupole
  length: 1.0
  name: quad1
- kind: Drift
  length: 0.5
  name: drift2
- MagneticMultipoleP:
    Bn1: -1.0
  kind: Quadrupole
  length: 1.0
  name: quad2
- kind: Drift
  length: 0.5
  name: drift3
```

This would be alternative to the custom read/write example in #8.