### PR TITLE
Line of Dict of Elements

### DIFF
--- a/schema/BaseElement.py
+++ b/schema/BaseElement.py
@@ -14,3 +14,12 @@ class BaseElement(BaseModel):
 
     # element name
     name: str
+
+    def model_dump(self, *args, **kwargs):
+        """This makes sure the element name property is moved out and up to a one-key dictionary"""
+        elem_dict = super().model_dump(*args, **kwargs)
+        name = elem_dict.pop("name", None)
+        if name is None:
+            raise ValueError("Element missing 'name' attribute")
+        data = [{name: elem_dict}]
+        return data

--- a/schema/BaseElement.py
+++ b/schema/BaseElement.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, ConfigDict
-from typing import Literal, Optional
+from typing import Literal
 
 
 class BaseElement(BaseModel):
@@ -12,5 +12,5 @@ class BaseElement(BaseModel):
     # not only when an instance of BaseElement is created
     model_config = ConfigDict(validate_assignment=True)
 
-    # Unique element name
-    name: Optional[str] = None
+    # element name
+    name: str

--- a/schema/Line.py
+++ b/schema/Line.py
@@ -73,12 +73,9 @@ class Line(BaseModel):
         # Reformat 'line' field as list of single-key dicts
         new_line = []
         for elem in self.line:
-            # The element's name is the dict key; dump all other fields except 'name'
-            elem_dict = elem.model_dump(exclude={"name"}, **kwargs)
-            name = getattr(elem, "name", None)
-            if name is None:
-                raise ValueError("Element missing 'name' attribute")
-            new_line.append({name: elem_dict})
+            #  Use custom dump for each line element
+            elem_dict = elem.model_dump(**kwargs)[0]
+            new_line.append(elem_dict)
 
         data["line"] = new_line
         return data


### PR DESCRIPTION
Overwrite validation and model dump.

Alternate implementation of #13 that does not make the Python API harder to use.