### PR TITLE
Rename `Line` as `BeamLine`

### DIFF
--- a/examples/fodo.py
+++ b/examples/fodo.py
@@ -11,7 +11,7 @@ from schema.MagneticMultipoleParameters import MagneticMultipoleParameters
 from schema.DriftElement import DriftElement
 from schema.QuadrupoleElement import QuadrupoleElement
 
-from schema.Line import Line
+from schema.BeamLine import BeamLine
 
 
 def main():
@@ -42,7 +42,7 @@ def main():
         length=0.5,
     )
     # Create line with all elements
-    line = Line(
+    line = BeamLine(
         line=[
             drift1,
             quad1,
@@ -63,7 +63,7 @@ def main():
     with open(yaml_file, "r") as file:
         yaml_data = yaml.safe_load(file)
     # Parse YAML data
-    loaded_line = Line(**yaml_data)
+    loaded_line = BeamLine(**yaml_data)
     # Validate loaded data
     assert line == loaded_line
     # Serialize to JSON
@@ -78,7 +78,7 @@ def main():
     with open(json_file, "r") as file:
         json_data = json.loads(file.read())
     # Parse JSON data
-    loaded_line = Line(**json_data)
+    loaded_line = BeamLine(**json_data)
     # Validate loaded data
     assert line == loaded_line
 

--- a/schema/BeamLine.py
+++ b/schema/BeamLine.py
@@ -7,14 +7,14 @@ from schema.DriftElement import DriftElement
 from schema.QuadrupoleElement import QuadrupoleElement
 
 
-class Line(BaseModel):
+class BeamLine(BaseModel):
     """A line of elements and/or other lines"""
 
     # Validate every time a new value is assigned to an attribute,
-    # not only when an instance of Line is created
+    # not only when an instance of BeamLine is created
     model_config = ConfigDict(validate_assignment=True)
 
-    kind: Literal["Line"] = "Line"
+    kind: Literal["BeamLine"] = "BeamLine"
 
     line: List[
         Annotated[
@@ -23,7 +23,7 @@ class Line(BaseModel):
                 ThickElement,
                 DriftElement,
                 QuadrupoleElement,
-                "Line",
+                "BeamLine",
             ],
             Field(discriminator="kind"),
         ]
@@ -82,4 +82,4 @@ class Line(BaseModel):
 
 
 # Avoid circular import issues
-Line.model_rebuild()
+BeamLine.model_rebuild()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,7 +11,7 @@ from schema.ThickElement import ThickElement
 from schema.DriftElement import DriftElement
 from schema.QuadrupoleElement import QuadrupoleElement
 
-from schema.Line import Line
+from schema.BeamLine import BeamLine
 
 
 def test_BaseElement():
@@ -96,15 +96,15 @@ def test_QuadrupoleElement():
     assert element.MagneticMultipoleP.Bn2 == element_magnetic_multipole_Bn2
     assert element.MagneticMultipoleP.Bs2 == element_magnetic_multipole_Bs2
     assert element.MagneticMultipoleP.tilt2 == element_magnetic_multipole_tilt2
-    # Serialize the Line object to YAML
+    # Serialize the BeamLine object to YAML
     yaml_data = yaml.dump(element.model_dump(), default_flow_style=False)
     print(f"\n{yaml_data}")
 
 
-def test_Line():
+def test_BeamLine():
     # Create first line with one base element
     element1 = BaseElement(name="element1")
-    line1 = Line(line=[element1])
+    line1 = BeamLine(line=[element1])
     assert line1.line == [element1]
     # Extend first line with one thick element
     element2 = ThickElement(name="element2", length=2.0)
@@ -112,7 +112,7 @@ def test_Line():
     assert line1.line == [element1, element2]
     # Create second line with one drift element
     element3 = DriftElement(name="element3", length=3.0)
-    line2 = Line(line=[element3])
+    line2 = BeamLine(line=[element3])
     # Extend first line with second line
     line1.line.extend(line2.line)
     assert line1.line == [element1, element2, element3]
@@ -124,8 +124,8 @@ def test_yaml():
     # Create one thick element
     element2 = ThickElement(name="element2", length=2.0)
     # Create line with both elements
-    line = Line(line=[element1, element2])
-    # Serialize the Line object to YAML
+    line = BeamLine(line=[element1, element2])
+    # Serialize the BeamLine object to YAML
     yaml_data = yaml.dump(line.model_dump(), default_flow_style=False)
     print(f"\n{yaml_data}")
     # Write the YAML data to a test file
@@ -135,11 +135,11 @@ def test_yaml():
     # Read the YAML data from the test file
     with open(test_file, "r") as file:
         yaml_data = yaml.safe_load(file)
-    # Parse the YAML data back into a Line object
-    loaded_line = Line(**yaml_data)
+    # Parse the YAML data back into a BeamLine object
+    loaded_line = BeamLine(**yaml_data)
     # Remove the test file
     os.remove(test_file)
-    # Validate loaded Line object
+    # Validate loaded BeamLine object
     assert line == loaded_line
 
 
@@ -149,8 +149,8 @@ def test_json():
     # Create one thick element
     element2 = ThickElement(name="element2", length=2.0)
     # Create line with both elements
-    line = Line(line=[element1, element2])
-    # Serialize the Line object to JSON
+    line = BeamLine(line=[element1, element2])
+    # Serialize the BeamLine object to JSON
     json_data = json.dumps(line.model_dump(), sort_keys=True, indent=2)
     print(f"\n{json_data}")
     # Write the JSON data to a test file
@@ -160,9 +160,9 @@ def test_json():
     # Read the JSON data from the test file
     with open(test_file, "r") as file:
         json_data = json.loads(file.read())
-    # Parse the JSON data back into a Line object
-    loaded_line = Line(**json_data)
+    # Parse the JSON data back into a BeamLine object
+    loaded_line = BeamLine(**json_data)
     # Remove the test file
     os.remove(test_file)
-    # Validate loaded Line object
+    # Validate loaded BeamLine object
     assert line == loaded_line


### PR DESCRIPTION
This PR renames `Line` as `BeamLine`, which I think is consistent with the current version of PALS, see, e.g.,
```yaml
- fodo_cell:
    kind: BeamLine
    line:
    - drift1
    - quad1
    - drift2:
        kind: Drift
        length: 0.5
    - quad2:
        inherit: quad1
        MagneticMultipoleP:
          Bn1: -1.0
    - drift1
```
extracted from https://github.com/campa-consortium/pals/blob/main/examples/fodo.pals.yaml.