### PR TITLE
Fix BeamLine name attribute

### DIFF
--- a/examples/fodo.py
+++ b/examples/fodo.py
@@ -62,7 +62,7 @@ def main():
     with open(yaml_file, "r") as file:
         yaml_data = yaml.safe_load(file)
     # Parse YAML data
-    loaded_line = BeamLine(**yaml_data[0])
+    loaded_line = BeamLine(**yaml_data)
     # Validate loaded data
     assert line == loaded_line
     # Serialize to JSON
@@ -77,7 +77,7 @@ def main():
     with open(json_file, "r") as file:
         json_data = json.loads(file.read())
     # Parse JSON data
-    loaded_line = BeamLine(**json_data[0])
+    loaded_line = BeamLine(**json_data)
     # Validate loaded data
     assert line == loaded_line
 

--- a/src/pals_schema/BaseElement.py
+++ b/src/pals_schema/BaseElement.py
@@ -21,5 +21,8 @@ class BaseElement(BaseModel):
         name = elem_dict.pop("name", None)
         if name is None:
             raise ValueError("Element missing 'name' attribute")
-        data = [{name: elem_dict}]
+        # Return a dict {name: properties} rather than a single-item list
+        # This makes the serialized form a plain dict so it can be passed to
+        # constructors using keyword expansion (e.g., Model(**data))
+        data = {name: elem_dict}
         return data

--- a/src/pals_schema/BeamLine.py
+++ b/src/pals_schema/BeamLine.py
@@ -78,17 +78,16 @@ class BeamLine(BaseElement):
 
     def model_dump(self, *args, **kwargs):
         """This makes sure the element name property is moved out and up to a one-key dictionary"""
-        # Use base element dump first and return a one-element list of the form
-        # [{key: value}], where 'key' is the name of the line and 'value' is a
-        # dict with all other properties
+        # Use base element dump first and return a dict {key: value}, where 'key'
+        # is the name of the line and 'value' is a dict with all other properties
         data = super().model_dump(*args, **kwargs)
-        # Reformat 'line' field as list of single-key dicts
+        # Reformat 'line' field as list of element dicts
         new_line = []
         for elem in self.line:
-            #  Use custom dump for each line element
-            elem_dict = elem.model_dump(**kwargs)[0]
+            # Use custom dump for each line element, which now returns a dict
+            elem_dict = elem.model_dump(**kwargs)
             new_line.append(elem_dict)
-        data[0][self.name]["line"] = new_line
+        data[self.name]["line"] = new_line
         return data
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -138,7 +138,7 @@ def test_yaml():
     with open(test_file, "r") as file:
         yaml_data = yaml.safe_load(file)
     # Parse the YAML data back into a BeamLine object
-    loaded_line = BeamLine(**yaml_data[0])
+    loaded_line = BeamLine(**yaml_data)
     # Remove the test file
     os.remove(test_file)
     # Validate loaded BeamLine object
@@ -163,7 +163,7 @@ def test_json():
     with open(test_file, "r") as file:
         json_data = json.loads(file.read())
     # Parse the JSON data back into a BeamLine object
-    loaded_line = BeamLine(**json_data[0])
+    loaded_line = BeamLine(**json_data)
     # Remove the test file
     os.remove(test_file)
     # Validate loaded BeamLine object


### PR DESCRIPTION
### Overview

With the implementation in the main branch, if we add a `name` attribute to the `line` object created in the FODO example, the attribute is ignored and the output is
```yaml
kind: Line
line:
- drift1:
    kind: Drift
    length: 0.25
- quad1:
    MagneticMultipoleP:
      Bn1: 1.0
    kind: Quadrupole
    length: 1.0
- drift2:
    kind: Drift
    length: 0.5
- quad2:
    MagneticMultipoleP:
      Bn1: -1.0
    kind: Quadrupole
    length: 1.0
- drift3:
    kind: Drift
    length: 0.5
```

This is not consistent with the example in https://github.com/campa-consortium/pals/blob/main/examples/fodo.pals.yaml.

With the implementation in this branch, if we add a `name` attribute to the `line` object created in the FODO example, the attribute is stored and the output is
```yaml
fodo_cell:
  kind: BeamLine
  line:
  - drift1:
      kind: Drift
      length: 0.25
  - quad1:
      MagneticMultipoleP:
        Bn1: 1.0
      kind: Quadrupole
      length: 1.0
  - drift2:
      kind: Drift
      length: 0.5
  - quad2:
      MagneticMultipoleP:
        Bn1: -1.0
      kind: Quadrupole
      length: 1.0
  - drift3:
      kind: Drift
      length: 0.5
```
which is consistent with the example in https://github.com/campa-consortium/pals/blob/main/examples/fodo.pals.yaml.

This is achieved primarily by deriving the `Line` (`BeamLine` after #15) class from the base element class `BaseElement` instead of deriving it from Pydantic's base model class `BaseModel`.

I also merged the custom field validation of the `line` field with the custom model validation, since we needed one anyways to fix the deserialization. I don't see why they should be separate.

I wonder if the right way to do this is using `@model_serializer` instead of `@model_validator`...

### To do
- [x] Serialization (fixed with [c391e43](https://github.com/campa-consortium/pals-python/pull/16/commits/c391e4305b91739f0ac366233368084d8d55ac0d), very few lines changed)
- [x] Deserialization (fixed with the custom model validator, many more lines changed)
- [x] Cleaning