### PR TITLE
Use semantic versioning for PyPI package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pals_schema"
-version = "25.08"
+version = "0.1.0"
 dependencies = [
   "pydantic",
   "pyyaml",


### PR DESCRIPTION
Use [semantic versioning](https://semver.org/) (MAJOR.MINOR.PATCH) for the PyPI package introduced in #18, instead of YY.MM. 

Based on the scheme, it seems to me like we should start with 0.1.0, correct?