### PR TITLE
Skip 'Element' suffix for common elements

### DIFF
--- a/examples/fodo.py
+++ b/examples/fodo.py
@@ -7,35 +7,35 @@ import yaml
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../src/")))
 
 from pals_schema.MagneticMultipoleParameters import MagneticMultipoleParameters
-from pals_schema.DriftElement import DriftElement
-from pals_schema.QuadrupoleElement import QuadrupoleElement
+from pals_schema.Drift import Drift
+from pals_schema.Quadrupole import Quadrupole
 from pals_schema.BeamLine import BeamLine
 
 
 def main():
-    drift1 = DriftElement(
+    drift1 = Drift(
         name="drift1",
         length=0.25,
     )
-    quad1 = QuadrupoleElement(
+    quad1 = Quadrupole(
         name="quad1",
         length=1.0,
         MagneticMultipoleP=MagneticMultipoleParameters(
             Bn1=1.0,
         ),
     )
-    drift2 = DriftElement(
+    drift2 = Drift(
         name="drift2",
         length=0.5,
     )
-    quad2 = QuadrupoleElement(
+    quad2 = Quadrupole(
         name="quad2",
         length=1.0,
         MagneticMultipoleP=MagneticMultipoleParameters(
             Bn1=-1.0,
         ),
     )
-    drift3 = DriftElement(
+    drift3 = Drift(
         name="drift3",
         length=0.5,
     )

--- a/src/pals_schema/BeamLine.py
+++ b/src/pals_schema/BeamLine.py
@@ -3,8 +3,8 @@ from typing import Annotated, List, Literal, Union
 
 from pals_schema.BaseElement import BaseElement
 from pals_schema.ThickElement import ThickElement
-from pals_schema.DriftElement import DriftElement
-from pals_schema.QuadrupoleElement import QuadrupoleElement
+from pals_schema.Drift import Drift
+from pals_schema.Quadrupole import Quadrupole
 
 
 class BeamLine(BaseElement):
@@ -21,8 +21,8 @@ class BeamLine(BaseElement):
             Union[
                 BaseElement,
                 ThickElement,
-                DriftElement,
-                QuadrupoleElement,
+                Drift,
+                Quadrupole,
                 "BeamLine",
             ],
             Field(discriminator="kind"),

--- a/src/pals_schema/Drift.py
+++ b/src/pals_schema/Drift.py
@@ -3,7 +3,7 @@ from typing import Literal
 from .ThickElement import ThickElement
 
 
-class DriftElement(ThickElement):
+class Drift(ThickElement):
     """A field free region"""
 
     # Discriminator field

--- a/src/pals_schema/Quadrupole.py
+++ b/src/pals_schema/Quadrupole.py
@@ -4,7 +4,7 @@ from .ThickElement import ThickElement
 from .MagneticMultipoleParameters import MagneticMultipoleParameters
 
 
-class QuadrupoleElement(ThickElement):
+class Quadrupole(ThickElement):
     """A quadrupole element"""
 
     # Discriminator field

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -11,8 +11,8 @@ from pydantic import ValidationError
 from pals_schema.MagneticMultipoleParameters import MagneticMultipoleParameters
 from pals_schema.BaseElement import BaseElement
 from pals_schema.ThickElement import ThickElement
-from pals_schema.DriftElement import DriftElement
-from pals_schema.QuadrupoleElement import QuadrupoleElement
+from pals_schema.Drift import Drift
+from pals_schema.Quadrupole import Quadrupole
 from pals_schema.BeamLine import BeamLine
 
 
@@ -45,11 +45,11 @@ def test_ThickElement():
     assert not passed
 
 
-def test_DriftElement():
+def test_Drift():
     # Create one drift element with custom name and length
     element_name = "drift_element"
     element_length = 1.0
-    element = DriftElement(
+    element = Drift(
         name=element_name,
         length=element_length,
     )
@@ -67,7 +67,7 @@ def test_DriftElement():
     assert not passed
 
 
-def test_QuadrupoleElement():
+def test_Quadrupole():
     # Create one drift element with custom name and length
     element_name = "quadrupole_element"
     element_length = 1.0
@@ -85,7 +85,7 @@ def test_QuadrupoleElement():
         Bs2=element_magnetic_multipole_Bs2,
         tilt2=element_magnetic_multipole_tilt2,
     )
-    element = QuadrupoleElement(
+    element = Quadrupole(
         name=element_name,
         length=element_length,
         MagneticMultipoleP=element_magnetic_multipole,
@@ -113,7 +113,7 @@ def test_BeamLine():
     line1.line.extend([element2])
     assert line1.line == [element1, element2]
     # Create second line with one drift element
-    element3 = DriftElement(name="element3", length=3.0)
+    element3 = Drift(name="element3", length=3.0)
     line2 = BeamLine(name="line2", line=[element3])
     # Extend first line with second line
     line1.line.extend(line2.line)


### PR DESCRIPTION
Skip the `Element` suffix for common elements such as drifts, quadrupoles, etc., and close #27. 