### PR TITLE
Env: Add `conda`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
+  - conda
   - pre-commit
   - pydantic
   - pytest


### PR DESCRIPTION
Having the `conda` command available is useful for IDE integration, e.g., in PyCharm.