### PR TITLE
Update RF & Aperture Parmeters

### DIFF
--- a/src/pals/parameters/ApertureParameters.py
+++ b/src/pals/parameters/ApertureParameters.py
@@ -1,4 +1,5 @@
-from typing import Literal
+from annotated_types import Ge
+from typing import Annotated, Literal
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -22,6 +23,6 @@ class ApertureParameters(BaseModel):
         "ENTRANCE_END", "CENTER", "EXIT_END", "BOTH_ENDS", "NOWHERE", "EVERYWHERE"
     ] = "ENTRANCE_END"
     material: str = ""
-    thickness: float = Field(default=0.0, ge=0.0)
+    thickness: Annotated[float, Ge(0.0)] = 0.0
     aperture_shifts_with_body: bool = False
     aperture_active: bool = True

--- a/src/pals/parameters/RFParameters.py
+++ b/src/pals/parameters/RFParameters.py
@@ -1,14 +1,17 @@
-from pydantic import BaseModel, Field
+from annotated_types import Ge
+from typing import Annotated, Literal
+
+from pydantic import BaseModel
 
 
 class RFParameters(BaseModel):
     """RF parameters"""
 
-    frequency: float = 0.0  # [Hz] RF frequency
-    harmon: int = 0  # [unitless] RF frequency harmonic number
+    frequency: Annotated[float, Ge(0.0)] = 0.0  # [Hz] RF frequency
+    harmon: Annotated[int, Ge(0)] = 0  # [unitless] RF frequency harmonic number
     voltage: float = 0.0  # [V] RF voltage
     gradient: float = 0.0  # [V/m] RF gradient
     phase: float = 0.0  # [unitless] RF phase in 0 to 2*pi
     multipass_phase: float = 0.0  # [unitless] RF Phase added to multipass elements
-    cavity_type: str = "STANDING_WAVE"  # [string] Cavity type
-    n_cell: int = Field(default=1, gt=0)  # [unitless] Number of cavity cells
+    cavity_type: Literal["STANDING_WAVE"] = "STANDING_WAVE"  # [string] Cavity type
+    n_cell: Annotated[int, Ge(1)] = 1  # [unitless] Number of cavity cells


### PR DESCRIPTION
- use `Literal` where only one value is allowed
- use standard lib (typing, annotated_types) where available