### PR TITLE
Rename CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: pals-python
+name: pals
 
 on:
   push:
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_tests:
-    name: unit tests
+  tests:
+    name: tests
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The CI workflow file was called `unit_tests.yml` and the job name was "unit tests". I propose that we rename the workflow file `tests.yml` and the job name "tests", since the workflow runs both unit tests and examples - not just unit tests. I would be open also to calling the workflow file `tests_and_examples.yml` and the job name "tests and examples".