### PR TITLE
Development Version: `0.4.0.dev`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pals_schema"
-version = "0.3.0"
+version = "0.4.0.dev"
 dependencies = [
   "pydantic",
   "pyyaml",


### PR DESCRIPTION
- [x] We just released `0.4.0`.

For the `main` development branch, we can indicate the next anticipated release + the Python-PEP'd `.dev` suffix until we tag it. (Remove the suffix for release.)