### PR TITLE
Add Gitleaks hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,9 @@ repos:
       args: [--fix, --exit-non-zero-on-fix]
     # Run the formatter
     - id: ruff-format
+
+# Scan for secret files that should not be committed
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.0
+  hooks:
+    - id: gitleaks


### PR DESCRIPTION
Gitleaks ([github.com/gitleaks/gitleaks](https://github.com/gitleaks/gitleaks)) is a tool for detecting secrets like passwords, API keys, and tokens in git repositories, files, and directories. 

The hook is supported by pre-commit and listed at [pre-commit.com/hooks.html](https://pre-commit.com/hooks.html) in the "secret scanning / security" section.

Note that I set version 8.30.0 intentionally after seeing it was set back (from 8.30.1) automatically by pre-commit's autoupdate in https://github.com/BLAST-AI-ML/synapse/pull/451.